### PR TITLE
file_transfer

### DIFF
--- a/DummyClient/client.cpp
+++ b/DummyClient/client.cpp
@@ -1,17 +1,25 @@
 #include "pch.h"
-
 #include "Session.h"
 #include "Service.h"
 #include "CorePch.h"
+#include "FileTransfer.h"
 
 CoreGlobal Core;
 
 using namespace std;
 
+// 패킷 ID 정의 - FileTransfer.h의 FileTransferPacketId 열거형과 맞추기
 enum PacketId
 {
     PKT_C_CHAT = 1,
-    PKT_S_CHAT = 2
+    PKT_S_CHAT = 2,
+
+    // 파일 전송 관련 패킷 ID (FileTransfer.h의 FileTransferPacketId와 일치시킴)
+    PKT_FILE_REQUEST = static_cast<uint16_t>(FileTransferPacketId::FileTransferRequest),
+    PKT_FILE_RESPONSE = static_cast<uint16_t>(FileTransferPacketId::FileTransferResponse),
+    PKT_FILE_DATA = static_cast<uint16_t>(FileTransferPacketId::FileDataChunk),
+    PKT_FILE_COMPLETE = static_cast<uint16_t>(FileTransferPacketId::FileTransferComplete),
+    PKT_FILE_ERROR = static_cast<uint16_t>(FileTransferPacketId::FileTransferError)
 };
 
 struct ChatData
@@ -19,21 +27,34 @@ struct ChatData
     char msg[100]; // 메시지 최대 99자 + null
 };
 
-class ClientSession : public PacketSession
+class ClientSession : public FilePacketSession
 {
-    static const vector<string> RANDOM_MESSAGES;
-
 public:
     ClientSession(asio::io_context& ioc)
-        : PacketSession(ioc)
+        : FilePacketSession(ioc)
         , _timer(ioc)
     {
+        // 파일 수신 디렉토리 설정
+        SetFileReceiveDirectory("./client_received_files");
+
+        // 파일 전송 완료 콜백 설정
+        GetFileTransferManager()->SetTransferCompleteCallback(
+            [this](uint32_t connectionId, bool success, const std::string& filePath) {
+                if (success) {
+                    cout << "File transfer completed: " << filePath << endl;
+
+                    // 모든 청크 전송 후 완료 메시지 
+                    SendChatPacket(("File transfer completed: " + fs::path(filePath).filename().string()).c_str());
+                }
+                else {
+                    cout << "File transfer failed: " << filePath << endl;
+                }
+            });
     }
 
     virtual void OnConnected() override
     {
         cout << "Connected to Server" << endl;
-        ScheduleRandomMessage();
     }
 
     virtual void OnRecvPacket(BYTE* buffer, int32_t len) override
@@ -44,9 +65,16 @@ public:
         {
             ChatData* chatData = reinterpret_cast<ChatData*>(buffer + sizeof(PacketHeader));
             cout << "Server Says: " << chatData->msg << endl;
-
-            // 다음 메시지 예약
-            ScheduleRandomMessage();
+        }
+        // 파일 전송 관련 패킷은 부모 클래스(FilePacketSession)에서 처리
+        else if (header->id == PKT_FILE_REQUEST ||
+            header->id == PKT_FILE_RESPONSE ||
+            header->id == PKT_FILE_DATA ||
+            header->id == PKT_FILE_COMPLETE ||
+            header->id == PKT_FILE_ERROR)
+        {
+            // 부모 클래스의 OnRecvPacket 호출
+            FilePacketSession::OnRecvPacket(buffer, len);
         }
     }
 
@@ -69,86 +97,117 @@ public:
         Send(sendBuffer);
     }
 
-private:
-    void ScheduleRandomMessage()
+    // 파일 전송 시작 메서드
+    bool SendFile(const std::string& filePath)
     {
-        _timer.expires_after(std::chrono::seconds(2)); // 2초마다
-        _timer.async_wait([this](const std::error_code& error)
-            {
-                if (!error)
-                {
-                    int index = rand() % RANDOM_MESSAGES.size();
-                    SendChatPacket(RANDOM_MESSAGES[index].c_str());
-                }
-            });
+        if (!fs::exists(filePath)) {
+            std::cout << "[Client] Error: File does not exist: " << filePath << std::endl;
+            return false;
+        }
+
+        // 파일 크기 로깅
+        std::error_code ec;
+        uintmax_t fileSize = fs::file_size(filePath, ec);
+        if (ec) {
+            std::cout << "[Client] Error reading file size: " << ec.message() << std::endl;
+            return false;
+        }
+
+        std::cout << "\n[Client] Starting file transfer: " << filePath << std::endl;
+        std::cout << "[Client] File size: " << fileSize << " bytes" << std::endl;
+
+        // 전송 시작
+        bool result = GetFileTransferManager()->StartFileSend(
+            shared_from_this(),
+            filePath,
+            FileTransferManager::DEFAULT_CHUNK_SIZE
+        );
+
+        if (result) {
+            std::cout << "[Client] File transfer initiated successfully" << std::endl;
+
+            // 첫 번째 청크 바로 전송 (다음 청크는 이 함수 내에서 자동으로 전송됨)
+            if (!GetFileTransferManager()->SendNextChunk(shared_from_this(), 1)) {
+                std::cerr << "[Client] Failed to send first chunk" << std::endl;
+                return false;
+            }
+        }
+        else {
+            std::cerr << "[Client] Failed to initiate file transfer" << std::endl;
+        }
+
+        return result;
+
     }
 
 private:
     asio::steady_timer _timer;
 };
 
-const vector<string> ClientSession::RANDOM_MESSAGES = {
-    "Hello from Client!--------------------------------------------------------",
-    "How are you doing?",
-    "Nice weather today!",
-    "I'm a happy client!",
-    "This is an automated message",
-    "Testing the connection",
-    "Ping from client",
-    "Another random message",
-    "Having fun with networking",
-    "Keep the server busy"
-};
+// 사용자 명령어 처리 함수
+void ProcessUserCommands(shared_ptr<ClientSession> session)
+{
+    cout << "=== File Transfer Client ===" << endl;
+    cout << "Commands:" << endl;
+    cout << "  /send <filepath> - Send a file to server" << endl;
+    cout << "  /quit - Quit the application" << endl;
+    cout << "  <message> - Send a chat message" << endl;
+    cout << "=========================" << endl;
+
+    string input;
+    while (true)
+    {
+        getline(cin, input);
+
+        // 종료 명령어
+        if (input == "/quit" || input == "q" || input == "Q")
+            break;
+
+        // 파일 전송 명령어: /send <filepath>
+        else if (input.substr(0, 6) == "/send ")
+        {
+            string filePath = input.substr(6);
+            cout << "Sending file: " << filePath << endl;
+
+            // 파일 전송 시작
+            if (!session->SendFile(filePath)) {
+                cout << "Failed to start file transfer" << endl;
+            }
+        }
+        // 일반 채팅 메시지
+        else
+        {
+            session->SendChatPacket(input.c_str());
+        }
+    }
+}
 
 int main()
 {
-    srand(static_cast<unsigned>(time(nullptr)));
     asio::io_context ioc;
 
-    // 클라이언트 수 설정
-    const int CLIENT_COUNT = 1;
-    vector<shared_ptr<ClientSession>> sessions;
-    vector<shared_ptr<ClientService>> services;
+    // 클라이언트 세션 생성
+    auto session = make_shared<ClientSession>(ioc);
+    auto service = make_shared<ClientService>(
+        ioc,
+        NetAddress("127.0.0.1", 7777),
+        [session](asio::io_context& ioc) { return session; },
+        1);
 
-    // 여러 클라이언트 생성
-    for (int i = 0; i < CLIENT_COUNT; i++)
-    {
-        auto session = make_shared<ClientSession>(ioc);
-        auto service = make_shared<ClientService>(
-            ioc,
-            NetAddress("127.0.0.1", 7777),
-            [session](asio::io_context& ioc) { return session; },
-            1);
+    // 서비스 시작
+    cout << "Connecting to server..." << endl;
+    service->Start();
 
-        sessions.push_back(session);
-        services.push_back(service);
-
-        // 각 서비스 시작
-        service->Start();
-    }
-
-    // worker 스레드 생성 (클라이언트 수에 따라 적절히 조정)
+    // IO 스레드 생성
     vector<thread> threads;
-    int threadCount = min(CLIENT_COUNT, 4); // 최대 4개 스레드 사용
+    threads.push_back(thread([&ioc]() {
+        ioc.run();
+        }));
 
-    for (int i = 0; i < threadCount; i++)
-    {
-        threads.push_back(thread([&ioc]()
-            {
-                ioc.run();
-            }));
-    }
+    // 메인 스레드에서 사용자 입력 처리
+    ProcessUserCommands(session);
 
-    // 메인 루프
-    while (true)
-    {
-        string cmd;
-        getline(cin, cmd);
-        if (cmd == "q" || cmd == "Q")
-            break;
-    }
-
-    // 정리
+    // 종료 처리
     ioc.stop();
     for (auto& t : threads)
         t.join();

--- a/ServerCoreLibrary/FileTransfer.cpp
+++ b/ServerCoreLibrary/FileTransfer.cpp
@@ -1,0 +1,576 @@
+#include "pch.h"
+#include "FileTransfer.h"
+#include "CoreGlobal.h"
+
+/*----------------
+    FileTransferManager
+-----------------*/
+FileTransferManager::FileTransferManager()
+{
+}
+
+FileTransferManager::~FileTransferManager()
+{
+    // 모든 파일 스트림 정리
+    std::lock_guard<std::mutex> guard(_lock);
+    for (auto& pair : _transfers)
+    {
+        if (pair.second.fileStream.is_open())
+            pair.second.fileStream.close();
+    }
+}
+
+bool FileTransferManager::StartFileSend(std::shared_ptr<Session> session, const std::string& filePath, uint32_t chunkSize)
+{
+    std::error_code ec;
+    if (!fs::exists(filePath, ec) || ec)
+        return false;
+
+    std::ifstream file(filePath, std::ios::binary);
+    if (!file.is_open())
+        return false;
+
+    // 파일 크기 계산
+    uint64_t fileSize = fs::file_size(filePath, ec);
+    if (ec)
+        return false;
+
+    // 전송 컨텍스트 생성
+    uint32_t connectionId;
+    {
+        std::lock_guard<std::mutex> guard(_lock);
+        connectionId = _nextConnectionId++;
+
+        FileTransferContext& context = _transfers[connectionId];
+        context.filePath = filePath;
+        context.fileStream = std::move(file);
+        context.fileSize = fileSize;
+        context.bytesSent = 0;
+        context.chunkSize = chunkSize;
+        context.chunksTotal = static_cast<uint32_t>((fileSize + chunkSize - 1) / chunkSize); // 올림 계산
+        context.chunksSent = 0;
+        context.isCompleted = false;
+    }
+
+    // 파일 전송 요청 패킷 전송
+    auto packet = CreateFileRequestPacket(filePath, fileSize, chunkSize);
+    session->Send(packet);
+
+    return true;
+}
+
+bool FileTransferManager::StartFileReceive(const std::string& targetDir, const FileHeader& header)
+{
+    // 디버깅 로그
+    std::cout << "\n[FileTransfer] Receiving file: " << header.filename << std::endl;
+    std::cout << "[FileTransfer] File size: " << header.fileSize << " bytes" << std::endl;
+    std::cout << "[FileTransfer] Total chunks: " << header.chunksTotal << std::endl;
+
+    // 파일 경로 구성
+    std::string filename(header.filename);
+    std::string filePath = targetDir + "/" + filename;
+
+    // 디렉토리 존재 확인 및 생성
+    if (!fs::exists(targetDir)) {
+        std::cout << "[FileTransfer] Creating directory: " << targetDir << std::endl;
+        std::error_code ec;
+        fs::create_directories(targetDir, ec);
+        if (ec) {
+            std::cerr << "[FileTransfer] Error creating directory: " << ec.message() << std::endl;
+            return false;
+        }
+    }
+
+    // 기존 파일이 있다면 백업
+    if (fs::exists(filePath)) {
+        std::string backupPath = filePath + ".bak";
+        std::error_code ec;
+        std::cout << "[FileTransfer] Backing up existing file to: " << backupPath << std::endl;
+        fs::rename(filePath, backupPath, ec);
+        if (ec) {
+            std::cerr << "[FileTransfer] Error backing up file: " << ec.message() << std::endl;
+            // 계속 진행할 수 있지만 경고는 표시
+        }
+    }
+
+    // 파일 생성 및 공간 할당
+    std::cout << "[FileTransfer] Creating file: " << filePath << std::endl;
+    std::ofstream file(filePath, std::ios::binary | std::ios::trunc);
+    if (!file.is_open()) {
+        std::cerr << "[FileTransfer] Error: Cannot create file: " << filePath << std::endl;
+        return false;
+    }
+
+    // 파일 크기만큼 공간 미리 할당
+    try {
+        file.seekp(header.fileSize - 1);
+        file.put(0);
+        file.flush();
+    }
+    catch (const std::exception& e) {
+        std::cerr << "[FileTransfer] Error pre-allocating file space: " << e.what() << std::endl;
+        file.close();
+        return false;
+    }
+
+    if (!file.good()) {
+        std::cerr << "[FileTransfer] Error writing to file" << std::endl;
+        file.close();
+        return false;
+    }
+
+    file.close();
+
+    // 전송 컨텍스트 생성
+    uint32_t connectionId;
+    {
+        std::lock_guard<std::mutex> guard(_lock);
+        connectionId = _nextConnectionId++;
+
+        FileTransferContext& context = _transfers[connectionId];
+        context.filePath = filePath;
+        context.fileSize = header.fileSize;
+        context.bytesSent = 0;
+        context.chunkSize = DEFAULT_CHUNK_SIZE;
+        context.chunksTotal = header.chunksTotal;
+        context.chunksSent = 0;
+        context.isCompleted = false;
+    }
+
+    std::cout << "[FileTransfer] Created transfer context with ID: " << connectionId << std::endl;
+    std::cout << "[FileTransfer] Target file path: " << filePath << std::endl;
+
+    return true;
+}
+
+bool FileTransferManager::ProcessFileChunk(const FileChunk& chunk, const void* data)
+{
+    // 디버깅 출력
+    std::cout << "[FileTransfer] Processing chunk: ID=" << chunk.chunkId
+        << ", Size=" << chunk.chunkSize
+        << ", IsLast=" << (chunk.isLast ? "Yes" : "No") << std::endl;
+
+    std::lock_guard<std::mutex> guard(_lock);
+
+    if (_transfers.empty()) {
+        std::cerr << "[FileTransfer] Error: No active file transfers" << std::endl;
+        return false;
+    }
+
+    // 가장 최근의 전송 컨텍스트 사용
+    auto it = _transfers.rbegin();
+    FileTransferContext& context = it->second;
+
+    std::cout << "[FileTransfer] Using transfer context: ID=" << it->first
+        << ", FilePath=" << context.filePath << std::endl;
+
+    // 파일 경로 디버그
+    std::cout << "[FileTransfer] Full file path: " << fs::absolute(context.filePath).string() << std::endl;
+
+    // 디렉토리 확인 및 생성
+    std::string dirPath = fs::path(context.filePath).parent_path().string();
+    if (!fs::exists(dirPath)) {
+        std::cout << "[FileTransfer] Creating directory: " << dirPath << std::endl;
+        std::error_code ec;
+        fs::create_directories(dirPath, ec);
+        if (ec) {
+            std::cerr << "[FileTransfer] Failed to create directory: " << ec.message() << std::endl;
+            return false;
+        }
+    }
+
+    // 파일 열기
+    std::ofstream file(context.filePath, std::ios::binary | std::ios::in | std::ios::out);
+    if (!file.is_open()) {
+        std::cerr << "[FileTransfer] Error: Cannot open file for writing: " << context.filePath << std::endl;
+
+        // 다른 모드로 시도
+        file.open(context.filePath, std::ios::binary | std::ios::trunc);
+        if (!file.is_open()) {
+            std::cerr << "[FileTransfer] Error: Still cannot open file after trying trunc mode" << std::endl;
+
+            // 마지막 시도: 다른 이름으로 저장
+            std::string altPath = dirPath + "/received_" + std::to_string(std::time(nullptr)) + ".bin";
+            file.open(altPath, std::ios::binary | std::ios::trunc);
+
+            if (!file.is_open()) {
+                std::cerr << "[FileTransfer] Error: All attempts to open file failed" << std::endl;
+                return false;
+            }
+
+            std::cout << "[FileTransfer] Opened alternative file path: " << altPath << std::endl;
+            context.filePath = altPath;
+        }
+    }
+
+    // 파일이 정상적으로 열렸다면 크기 확인
+    std::error_code ec;
+    uintmax_t fileSize = fs::file_size(context.filePath, ec);
+    if (!ec) {
+        std::cout << "[FileTransfer] Current file size: " << fileSize << " bytes" << std::endl;
+
+        // 파일이 아직 작다면 미리 공간 할당
+        if (fileSize < context.fileSize) {
+            file.seekp(context.fileSize - 1);
+            file.put(0);
+            file.flush();
+            std::cout << "[FileTransfer] Pre-allocated file space to " << context.fileSize << " bytes" << std::endl;
+        }
+    }
+
+    // 파일 포인터 이동
+    uint64_t offset = static_cast<uint64_t>(chunk.chunkId) * context.chunkSize;
+    file.seekp(offset);
+
+    std::cout << "[FileTransfer] Writing " << chunk.chunkSize << " bytes at offset " << offset << std::endl;
+
+    // 데이터 쓰기
+    file.write(static_cast<const char*>(data), chunk.chunkSize);
+
+    if (!file.good()) {
+        std::cerr << "[FileTransfer] Error: Failed to write data to file" << std::endl;
+        file.close();
+        return false;
+    }
+
+    file.flush();
+    file.close();
+
+    // 쓰기 확인
+    std::ifstream checkFile(context.filePath, std::ios::binary);
+    if (checkFile.is_open()) {
+        checkFile.seekg(0, std::ios::end);
+        std::streampos fileSize = checkFile.tellg();
+        checkFile.close();
+        std::cout << "[FileTransfer] File size after write: " << fileSize << " bytes" << std::endl;
+    }
+
+    // 전송 상태 업데이트
+    context.chunksSent++;
+    context.bytesSent += chunk.chunkSize;
+
+    // 진행 상황 출력
+    double progressPct = static_cast<double>(context.bytesSent) * 100.0 / context.fileSize;
+    std::cout << "[FileTransfer] Progress: " << context.chunksSent << "/" << context.chunksTotal
+        << " chunks (" << std::fixed << std::setprecision(2) << progressPct << "%)" << std::endl;
+
+    // 모든 청크를 받았는지 확인
+    if (chunk.isLast || context.chunksSent >= context.chunksTotal) {
+        context.isCompleted = true;
+
+        // 파일 크기 검증
+        std::error_code ec;
+        uintmax_t actualSize = fs::file_size(context.filePath, ec);
+        if (ec) {
+            std::cerr << "[FileTransfer] Error checking final file size: " << ec.message() << std::endl;
+        }
+        else {
+            std::cout << "[FileTransfer] Final file size: " << actualSize << " bytes "
+                << "(expected: " << context.fileSize << " bytes)" << std::endl;
+        }
+
+        std::cout << "[FileTransfer] File transfer completed: " << context.filePath << std::endl;
+
+        if (_transferCompleteCallback) {
+            std::cout << "[FileTransfer] Calling transfer complete callback" << std::endl;
+            _transferCompleteCallback(it->first, true, context.filePath);
+        }
+    }
+
+    return true;
+}
+
+// SendNextChunk 함수도 수정이 필요합니다.
+bool FileTransferManager::SendNextChunk(std::shared_ptr<Session> session, uint32_t connectionId)
+{
+    std::lock_guard<std::mutex> guard(_lock);
+
+    auto it = _transfers.find(connectionId);
+    if (it == _transfers.end()) {
+        // connectionId 1로도 시도해 봄 (첫 번째 전송일 가능성)
+        it = _transfers.find(1);
+        if (it == _transfers.end()) {
+            std::cerr << "Error: No file transfer found with ID " << connectionId << std::endl;
+            return false;
+        }
+    }
+
+    FileTransferContext& context = it->second;
+
+    if (context.isCompleted) {
+        std::cout << "File transfer already completed" << std::endl;
+        return true;
+    }
+
+    if (!context.fileStream.is_open()) {
+        // 파일이 닫혀있으면 다시 열기
+        context.fileStream.open(context.filePath, std::ios::binary);
+        if (!context.fileStream.is_open()) {
+            std::cerr << "Error: Cannot open file for reading: " << context.filePath << std::endl;
+            return false;
+        }
+    }
+
+    // 현재 위치로 이동
+    context.fileStream.seekg(context.bytesSent);
+
+    // 남은 사이즈 계산
+    uint64_t remainingBytes = context.fileSize - context.bytesSent;
+    if (remainingBytes == 0) {
+        // 전송 완료
+        context.isCompleted = true;
+        context.fileStream.close();
+
+        std::cout << "File transfer completed (no more bytes to send)" << std::endl;
+
+        if (_transferCompleteCallback)
+            _transferCompleteCallback(connectionId, true, context.filePath);
+
+        return true;
+    }
+
+    // 이번에 전송할 청크 크기 결정
+    // SendBuffer의 최대 크기를 고려하여 청크 크기 제한
+    const uint32_t maxChunkSize = SendBufferChunk::SEND_BUFFER_CHUNK_SIZE - sizeof(FileChunk) - 16; // 추가 안전 마진
+    uint32_t currentChunkSize = static_cast<uint32_t>(std::min<uint64_t>(remainingBytes, context.chunkSize));
+    currentChunkSize = std::min(currentChunkSize, maxChunkSize);
+
+    bool isLastChunk = (remainingBytes <= currentChunkSize);
+
+    // 파일에서 데이터 읽기
+    std::vector<char> buffer(currentChunkSize);
+    context.fileStream.read(buffer.data(), currentChunkSize);
+
+    if (!context.fileStream.good() && !context.fileStream.eof()) {
+        std::cerr << "Error: Failed to read data from file" << std::endl;
+        return false;
+    }
+
+    // 청크 패킷 생성 및 전송
+    auto packet = CreateFileChunkPacket(buffer.data(), currentChunkSize, context.chunksSent, isLastChunk);
+    if (!packet) {
+        std::cerr << "Error: Failed to create file chunk packet" << std::endl;
+        return false;
+    }
+
+    session->Send(packet);
+
+    std::cout << "Sent chunk " << context.chunksSent
+        << " (" << currentChunkSize << " bytes, "
+        << (isLastChunk ? "last chunk" : "more to come") << ")" << std::endl;
+
+    // 상태 업데이트
+    context.bytesSent += currentChunkSize;
+    context.chunksSent++;
+
+    // 모든 청크를 전송했는지 확인
+    if (isLastChunk) {
+        context.isCompleted = true;
+        context.fileStream.close();
+
+        std::cout << "File transfer completed (last chunk sent)" << std::endl;
+
+        if (_transferCompleteCallback)
+            _transferCompleteCallback(connectionId, true, context.filePath);
+    }
+    else {
+        // 다음 청크 전송 예약 (짧은 지연 후)
+        std::thread([this, session, connectionId]() {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            SendNextChunk(session, connectionId);
+            }).detach();
+    }
+
+    return true;
+}
+
+void FileTransferManager::CancelTransfer(uint32_t connectionId)
+{
+    std::lock_guard<std::mutex> guard(_lock);
+
+    auto it = _transfers.find(connectionId);
+    if (it != _transfers.end())
+    {
+        if (it->second.fileStream.is_open())
+            it->second.fileStream.close();
+
+        _transfers.erase(it);
+    }
+}
+
+void FileTransferManager::SetTransferCompleteCallback(TransferCompleteCallback callback)
+{
+    _transferCompleteCallback = callback;
+}
+
+std::shared_ptr<SendBuffer> FileTransferManager::CreateFileRequestPacket(const std::string& filePath, uint64_t fileSize, uint32_t chunkSize)
+{
+    // 파일 이름만 추출
+    std::string filename = fs::path(filePath).filename().string();
+
+    // 패킷 크기 계산
+    uint16_t packetSize = sizeof(FileHeader);
+
+    // SendBuffer 생성
+    auto sendBuffer = GSendBufferManager->Open(packetSize);
+
+    // 패킷 구성
+    FileHeader* header = reinterpret_cast<FileHeader*>(sendBuffer->Buffer());
+    header->size = packetSize;
+    header->id = static_cast<uint16_t>(FileTransferPacketId::FileTransferRequest);
+
+    strncpy_s(header->filename, filename.c_str(), filename.length());
+    header->filename[filename.length()] = '\0';
+
+    header->fileSize = fileSize;
+    header->chunksTotal = static_cast<uint32_t>((fileSize + chunkSize - 1) / chunkSize);
+
+    sendBuffer->Close(packetSize);
+    return sendBuffer;
+}
+
+std::shared_ptr<SendBuffer> FileTransferManager::CreateFileChunkPacket(const void* data, uint32_t chunkSize, uint32_t chunkId, bool isLast)
+{
+    // 패킷 크기 계산
+    uint16_t packetSize = sizeof(FileChunk) + chunkSize;
+
+    // SendBuffer 최대 크기 확인 (SendBufferChunk::SEND_BUFFER_CHUNK_SIZE보다 작아야 함)
+    if (packetSize > SendBufferChunk::SEND_BUFFER_CHUNK_SIZE) {
+        std::cerr << "Error: Chunk size too large for SendBuffer. Max allowed: "
+            << (SendBufferChunk::SEND_BUFFER_CHUNK_SIZE - sizeof(FileChunk))
+            << ", Requested: " << chunkSize << std::endl;
+        return nullptr;
+    }
+
+    // SendBuffer 생성
+    auto sendBuffer = GSendBufferManager->Open(packetSize);
+    if (!sendBuffer) {
+        std::cerr << "Error: Failed to allocate SendBuffer for file chunk" << std::endl;
+        return nullptr;
+    }
+
+    // 패킷 구성
+    FileChunk* chunk = reinterpret_cast<FileChunk*>(sendBuffer->Buffer());
+    chunk->size = packetSize;
+    chunk->id = static_cast<uint16_t>(FileTransferPacketId::FileDataChunk);
+    chunk->chunkId = chunkId;
+    chunk->chunkSize = chunkSize;
+    chunk->isLast = isLast ? 1 : 0;
+
+    // 데이터 복사
+    memcpy(chunk + 1, data, chunkSize);
+
+    sendBuffer->Close(packetSize);
+    return sendBuffer;
+}
+
+/*----------------
+    FilePacketSession
+-----------------*/
+FilePacketSession::FilePacketSession(asio::io_context& ioc)
+    : PacketSession(ioc)
+{
+    _fileTransferManager = std::make_shared<FileTransferManager>();
+}
+
+void FilePacketSession::SetFileReceiveDirectory(const std::string& dir)
+{
+    _fileReceiveDirectory = dir;
+
+    // 디렉토리가 존재하지 않으면 생성
+    if (!fs::exists(dir))
+        fs::create_directories(dir);
+}
+
+void FilePacketSession::OnRecvPacket(BYTE* buffer, int32_t len)
+{
+    PacketHeader* header = reinterpret_cast<PacketHeader*>(buffer);
+    uint16_t packetId = header->id;
+
+    // 디버깅: 모든 패킷 정보 출력
+    std::cout << "[FilePacketSession] Received packet: ID=" << packetId
+        << ", Size=" << header->size << std::endl;
+
+    // FileTransferPacketId와 비교 (명시적 캐스팅)
+    if (packetId == static_cast<uint16_t>(FileTransferPacketId::FileTransferRequest)) {
+        FileHeader* fileHeader = reinterpret_cast<FileHeader*>(buffer);
+        std::cout << "[FilePacketSession] File transfer request: " << fileHeader->filename << std::endl;
+        HandleFileRequest(buffer);
+    }
+    else if (packetId == static_cast<uint16_t>(FileTransferPacketId::FileTransferResponse)) {
+        std::cout << "[FilePacketSession] File transfer response" << std::endl;
+        HandleFileResponse(buffer);
+    }
+    else if (packetId == static_cast<uint16_t>(FileTransferPacketId::FileDataChunk)) {
+        FileChunk* chunk = reinterpret_cast<FileChunk*>(buffer);
+        std::cout << "[FilePacketSession] File data chunk: ID=" << chunk->chunkId << std::endl;
+        HandleFileChunk(buffer);
+    }
+    else if (packetId == static_cast<uint16_t>(FileTransferPacketId::FileTransferComplete)) {
+        std::cout << "[FilePacketSession] File transfer complete" << std::endl;
+        HandleFileComplete(buffer);
+    }
+    else if (packetId == static_cast<uint16_t>(FileTransferPacketId::FileTransferError)) {
+        std::cout << "[FilePacketSession] File transfer error" << std::endl;
+        // 오류 처리
+    }
+    else {
+        std::cout << "[FilePacketSession] Unknown packet type: " << packetId << std::endl;
+    }
+}
+
+//==========================================
+// FilePacketSession.cpp의 HandleFileRequest 함수 수정
+//==========================================
+
+void FilePacketSession::HandleFileRequest(BYTE* buffer)
+{
+    FileHeader* header = reinterpret_cast<FileHeader*>(buffer);
+
+    std::cout << "\n[FilePacketSession] File request received: " << header->filename << std::endl;
+    std::cout << "[FilePacketSession] File size: " << header->fileSize << " bytes" << std::endl;
+    std::cout << "[FilePacketSession] Total chunks: " << header->chunksTotal << std::endl;
+    std::cout << "[FilePacketSession] Receive directory: " << _fileReceiveDirectory << std::endl;
+
+    // 파일 수신 시작
+    bool result = _fileTransferManager->StartFileReceive(_fileReceiveDirectory, *header);
+
+    if (result) {
+        std::cout << "[FilePacketSession] File receive started successfully" << std::endl;
+    }
+    else {
+        std::cerr << "[FilePacketSession] Failed to start file receive" << std::endl;
+    }
+}
+
+
+void FilePacketSession::HandleFileResponse(BYTE* buffer)
+{
+    // TODO: 파일 전송 요청에 대한 응답 처리
+}
+
+void FilePacketSession::HandleFileChunk(BYTE* buffer)
+{
+    FileChunk* chunk = reinterpret_cast<FileChunk*>(buffer);
+    void* data = chunk + 1; // 데이터는 헤더 바로 뒤에 위치
+
+    std::cout << "[FilePacketSession] Processing file chunk: ID=" << chunk->chunkId
+        << ", Size=" << chunk->chunkSize
+        << ", IsLast=" << (chunk->isLast ? "Yes" : "No") << std::endl;
+
+    bool result = _fileTransferManager->ProcessFileChunk(*chunk, data);
+
+    if (!result) {
+        std::cerr << "[FilePacketSession] Failed to process file chunk" << std::endl;
+    }
+
+    // 마지막 청크면 완료 처리
+    if (chunk->isLast) {
+        std::cout << "[FilePacketSession] Last chunk received, file transfer complete" << std::endl;
+    }
+}
+
+void FilePacketSession::HandleFileComplete(BYTE* buffer)
+{
+    // TODO: 파일 전송 완료 처리
+}

--- a/ServerCoreLibrary/FileTransfer.h
+++ b/ServerCoreLibrary/FileTransfer.h
@@ -1,0 +1,118 @@
+#pragma once
+#include "Session.h"
+#include "SendBuffer.h"
+#include <fstream>
+#include <filesystem>
+#include <map>
+
+namespace fs = std::filesystem;
+
+/*----------------
+    FileHeader
+-----------------*/
+struct FileHeader : public PacketHeader
+{
+    char filename[256];  // 최대 파일 이름 길이
+    uint64_t fileSize;   // 전체 파일 크기
+    uint32_t chunksTotal; // 총 청크 수
+};
+
+/*----------------
+    FileChunk
+-----------------*/
+struct FileChunk : public PacketHeader
+{
+    uint32_t chunkId;    // 청크 번호
+    uint32_t chunkSize;  // 청크 크기
+    uint8_t isLast;      // 마지막 청크 여부
+    // 데이터는 이 구조체 뒤에 따라옴
+};
+
+enum class FileTransferPacketId : uint16_t
+{
+    FileTransferRequest = 100,
+    FileTransferResponse = 101,
+    FileDataChunk = 102,
+    FileTransferComplete = 103,
+    FileTransferError = 104
+
+};
+
+/*----------------
+    FileTransferManager
+-----------------*/
+class FileTransferManager
+{
+public:
+    // 청크 크기를 SendBufferChunk::SEND_BUFFER_CHUNK_SIZE 보다 작게 설정
+    // SendBuffer.h에서 SEND_BUFFER_CHUNK_SIZE는 일반적으로 6000 (약 6KB)
+    // 여기서는 안전하게 4KB로 설정
+    static const uint32_t DEFAULT_CHUNK_SIZE = 4 * 1024;
+
+    struct FileTransferContext
+    {
+        std::string filePath;
+        std::ifstream fileStream;
+        uint64_t fileSize;
+        uint64_t bytesSent;
+        uint32_t chunkSize;
+        uint32_t chunksTotal;
+        uint32_t chunksSent;
+        bool isCompleted;
+    };
+
+    FileTransferManager();
+    ~FileTransferManager();
+
+    // 파일 전송 시작 (송신자용)
+    bool StartFileSend(std::shared_ptr<Session> session, const std::string& filePath, uint32_t chunkSize = DEFAULT_CHUNK_SIZE);
+
+    // 파일 수신 시작 (수신자용)
+    bool StartFileReceive(const std::string& targetDir, const FileHeader& header);
+
+    // 파일 청크 처리 (수신자용)
+    bool ProcessFileChunk(const FileChunk& chunk, const void* data);
+
+    // 다음 청크 전송 (송신자용)
+    bool SendNextChunk(std::shared_ptr<Session> session, uint32_t connectionId);
+
+    // 전송 취소
+    void CancelTransfer(uint32_t connectionId);
+
+    // 전송 완료 이벤트 콜백 등록
+    using TransferCompleteCallback = std::function<void(uint32_t connectionId, bool success, const std::string& filePath)>;
+    void SetTransferCompleteCallback(TransferCompleteCallback callback);
+
+private:
+    std::shared_ptr<SendBuffer> CreateFileRequestPacket(const std::string& filePath, uint64_t fileSize, uint32_t chunkSize);
+    std::shared_ptr<SendBuffer> CreateFileChunkPacket(const void* data, uint32_t chunkSize, uint32_t chunkId, bool isLast);
+
+    std::mutex _lock;
+    std::map<uint32_t, FileTransferContext> _transfers; // connectionId -> 전송 컨텍스트
+    TransferCompleteCallback _transferCompleteCallback;
+    uint32_t _nextConnectionId = 1;
+};
+
+/*----------------
+    FilePacketSession
+-----------------*/
+class FilePacketSession : public PacketSession
+{
+public:
+    FilePacketSession(asio::io_context& ioc);
+
+    void SetFileReceiveDirectory(const std::string& dir);
+    std::shared_ptr<FileTransferManager> GetFileTransferManager() { return _fileTransferManager; }
+
+protected:
+    virtual void OnRecvPacket(BYTE* buffer, int32_t len) override;
+
+private:
+    void HandleFileRequest(BYTE* buffer);
+    void HandleFileResponse(BYTE* buffer);
+    void HandleFileChunk(BYTE* buffer);
+    void HandleFileComplete(BYTE* buffer);
+
+    std::shared_ptr<FileTransferManager> _fileTransferManager;
+    std::string _fileReceiveDirectory = "./received_files";
+};

--- a/ServerCoreLibrary/SendBuffer.h
+++ b/ServerCoreLibrary/SendBuffer.h
@@ -27,6 +27,7 @@ private:
 --------------------*/
 class SendBufferChunk : public std::enable_shared_from_this<SendBufferChunk>
 {
+public:
     enum { SEND_BUFFER_CHUNK_SIZE = 6000 };
 
 public:

--- a/ServerCoreLibrary/ServerCoreLibrary.vcxproj
+++ b/ServerCoreLibrary/ServerCoreLibrary.vcxproj
@@ -155,6 +155,7 @@
     <ClInclude Include="AsioCore.h" />
     <ClInclude Include="CoreGlobal.h" />
     <ClInclude Include="CoreTLS.h" />
+    <ClInclude Include="FileTransfer.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="CorePch.h" />
     <ClInclude Include="NetAddress.h" />
@@ -177,6 +178,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="FileTransfer.cpp" />
     <ClCompile Include="NetAddress.cpp" />
     <ClCompile Include="pch.cpp" />
     <ClCompile Include="RecvBuffer.cpp" />

--- a/ServerCoreLibrary/ServerCoreLibrary.vcxproj.filters
+++ b/ServerCoreLibrary/ServerCoreLibrary.vcxproj.filters
@@ -57,6 +57,9 @@
     <ClInclude Include="SendBuffer.h">
       <Filter>Network</Filter>
     </ClInclude>
+    <ClInclude Include="FileTransfer.h">
+      <Filter>Network</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Session.cpp">
@@ -99,6 +102,9 @@
       <Filter>Network</Filter>
     </ClCompile>
     <ClCompile Include="SendBuffer.cpp">
+      <Filter>Network</Filter>
+    </ClCompile>
+    <ClCompile Include="FileTransfer.cpp">
       <Filter>Network</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
네, 청크 크기와 파일 송수신 코드에 대해 더 자세히 설명해 드리겠습니다.

## 청크 크기 설정에 관한 설명

```cpp
// 청크 크기를 SendBufferChunk::SEND_BUFFER_CHUNK_SIZE 보다 작게 설정
// SendBuffer.h에서 SEND_BUFFER_CHUNK_SIZE는 일반적으로 6000 (약 6KB)
// 여기서는 안전하게 4KB로 설정
static const uint32_t DEFAULT_CHUNK_SIZE = 4 * 1024;
```

### SEND_BUFFER_CHUNK_SIZE가 6000인 이유

1. **메모리 관리 최적화**: 
   - 6000바이트(약 6KB)는 네트워크 패킷 전송에 적절한 중간 크기입니다.
   - 너무 작으면 패킷 오버헤드(헤더 등)로 인해 효율이 낮아지고, 너무 크면 메모리 사용량이 증가하고 네트워크 지연이 발생할 수 있습니다.

2. **MTU 고려**: 
   - 일반적인 이더넷 MTU(Maximum Transmission Unit)는 1500바이트입니다.
   - 6000바이트는 약 4개의 이더넷 프레임으로 분할되는 크기로, 네트워크 효율성과 메모리 사용 간의 균형을 제공합니다.

3. **구현 선택**: 
   - 라이브러리 작성자가 실험과 경험을 바탕으로 선택한 값으로, 일반적인 사용 사례에 적합하도록 설계되었습니다.

### DEFAULT_CHUNK_SIZE가 4KB(4096바이트)인 이유

1. **안전성**: 
   - SendBufferChunk::SEND_BUFFER_CHUNK_SIZE(6000바이트)보다 작아야 assertion 오류를 방지할 수 있습니다.
   - 4KB는 SendBuffer에 들어갈 수 있는 안전한 크기입니다.

2. **메모리 페이지 크기 정렬**: 
   - 4KB는 대부분의 시스템에서 메모리 페이지 크기와 일치하여 메모리 관리 최적화에 도움이 됩니다.
   - 운영체제의 메모리 페이지 크기와 일치하면 메모리 할당 및 해제가 더 효율적입니다.

3. **표준 크기**: 
   - 4KB는 파일 시스템 블록 크기 등 많은 시스템에서 표준으로 사용되는 크기입니다.
   - 이 크기를 사용하면 다양한 시스템에서 호환성이 좋습니다.

4. **헤더 공간 고려**: 
   - 실제 SendBuffer에는 청크 데이터 외에도 패킷 헤더가 추가됩니다.
   - 4KB 데이터 + 헤더 크기를 합쳐도 6KB보다 작아 안전합니다.

## 파일 송수신 코드 설명

### 파일 송신 과정

1. **송신 초기화 (StartFileSend 함수)**:
```cpp
bool FileTransferManager::StartFileSend(std::shared_ptr<Session> session, const std::string& filePath, uint32_t chunkSize)
{
    // 파일 존재 확인 및 열기
    // 파일 크기 계산
    // 전송 컨텍스트 생성 (_transfers 맵에 저장)
    // 파일 전송 요청 패킷 전송
    return true;
}
```
- 파일 정보(경로, 크기)를 확인하고 전송 컨텍스트를 생성합니다.
- 중요: 파일 요청 패킷을 먼저 보내 서버에 파일 수신 준비를 요청합니다.
- 이 단계에서는 실제 파일 내용이 아닌 메타데이터만 전송됩니다.

2. **청크 전송 (SendNextChunk 함수)**:
```cpp
bool FileTransferManager::SendNextChunk(std::shared_ptr<Session> session, uint32_t connectionId)
{
    // 전송 컨텍스트 찾기
    // 파일 위치 이동
    // 청크 크기 결정 (남은 데이터와 최대 크기 중 작은 것)
    // 파일에서 데이터 읽기
    // 청크 패킷 생성 및 전송
    // 다음 청크 전송 예약 (마지막이 아니면)
    return true;
}
```
- 파일을 작은 청크로 나누어 순차적으로 전송합니다.
- 각 청크마다 파일에서 데이터를 읽어 패킷으로 만들어 전송합니다.
- 마지막 청크가 아니면 짧은 지연 후 다음 청크 전송을 예약합니다.
- 이 함수는 첫 청크 전송 후 재귀적으로 호출되어 모든 청크를 전송합니다.

### 파일 수신 과정

1. **수신 초기화 (StartFileReceive 함수)**:
```cpp
bool FileTransferManager::StartFileReceive(const std::string& targetDir, const FileHeader& header)
{
    // 파일 경로 구성
    // 디렉토리 존재 확인 및 생성
    // 파일 생성 및 공간 할당
    // 전송 컨텍스트 생성 (_transfers 맵에 저장)
    return true;
}
```
- 클라이언트로부터 받은 파일 메타데이터를 기반으로 수신 준비를 합니다.
- 필요한 디렉토리를 확인/생성하고, 파일을 미리 생성합니다.
- 수신할 파일의 총 크기만큼 공간을 미리 할당하여 효율성을 높입니다.

2. **청크 처리 (ProcessFileChunk 함수)**:
```cpp
bool FileTransferManager::ProcessFileChunk(const FileChunk& chunk, const void* data)
{
    // 전송 컨텍스트 찾기
    // 파일 열기
    // 해당 위치(offset)로 이동
    // 데이터 쓰기
    // 전송 진행 상황 업데이트
    // 모든 청크 수신 확인 및 완료 처리
    return true;
}
```
- 클라이언트로부터 받은 각 파일 청크를 처리합니다.
- 청크 ID를 기반으로 파일의 정확한 위치에 데이터를 씁니다.
- 진행 상황을 추적하고, 마지막 청크 수신 시 전송 완료 처리를 합니다.

### 주요 처리 흐름

1. **파일 송신 측 (클라이언트)**:
   - 사용자가 `/send` 명령어로 파일 전송 요청
   - `StartFileSend` 호출하여 파일 요청 패킷 전송
   - `SendNextChunk`를 재귀적으로 호출하여 모든 청크 전송
   - 마지막 청크 전송 후 완료 처리

2. **파일 수신 측 (서버)**:
   - 파일 요청 패킷 수신 시 `HandleFileRequest` 호출
   - `StartFileReceive` 호출하여 파일 수신 준비
   - 각 청크 수신 시 `HandleFileChunk` → `ProcessFileChunk` 호출
   - 모든 청크 수신 후 완료 콜백 호출

### 중요한 최적화 포인트

1. **패킷 ID 충돌 방지**:
   - 파일 전송 패킷 ID(100~104)와 채팅 패킷 ID(1~2)를 분리하여 충돌 방지

2. **청크 크기 최적화**:
   - SendBuffer의 크기 제한을 고려한 안전한 청크 크기 설정

3. **비동기 처리**:
   - 청크 전송을 짧은 지연 후 예약하여 네트워크 부하 분산

4. **파일 공간 선할당**:
   - 파일 크기를 미리 알기 때문에 디스크 공간을 미리 할당하여 I/O 효율 향상

5. **오류 처리 및 복구**:
   - 디렉토리 생성, 파일 열기 등 각 단계에서 오류를 처리하고 가능한 복구 시도

이 파일 전송 구현은 네트워크 프로그래밍의 중요한 개념들(버퍼 관리, 청크 처리, 비동기 I/O)을 활용하여 효율적이고 안정적인 파일 전송을 구현한 좋은 예시입니다.