### PR TITLE
variable_name

### DIFF
--- a/ServerCoreLibrary/MemoryPool.cpp
+++ b/ServerCoreLibrary/MemoryPool.cpp
@@ -3,7 +3,7 @@
 #include "SendBuffer.h" // SendBufferChunk::SEND_BUFFER_CHUNK_SIZE 사용을 위해
 
 
-MemoryPool::MemoryPool(uint32_t allocSize) : _allocSize(allocSize)
+MemoryPool::MemoryPool(uint32 allocSize) : _allocSize(allocSize)
 {
 }
 
@@ -40,10 +40,10 @@ MemoryHeader* MemoryPool::Pop()
 MemoryPoolManager::MemoryPoolManager()
 {
     // 각 사이즈별 메모리 풀 생성
-    for (uint32_t size = 32; size <= 1024; size += 32)
+    for (uint32 size = 32; size <= 1024; size += 32)
         _pools[size] = new MemoryPool(size);
 
-    for (uint32_t size = 1024 + 128; size <= 4096; size += 128)
+    for (uint32 size = 1024 + 128; size <= 4096; size += 128)
         _pools[size] = new MemoryPool(size);
 
     // 64KB짜리 청크 전용 풀
@@ -56,7 +56,7 @@ MemoryPoolManager::~MemoryPoolManager()
         delete pair.second;
 }
 
-void* MemoryPoolManager::Allocate(uint32_t size)
+void* MemoryPoolManager::Allocate(uint32 size)
 {
     MemoryPool* pool = nullptr;
 

--- a/ServerCoreLibrary/SendBuffer.cpp
+++ b/ServerCoreLibrary/SendBuffer.cpp
@@ -2,7 +2,7 @@
 #include "SendBuffer.h"
 
 SendBuffer::SendBuffer(std::shared_ptr<SendBufferChunk> owner, BYTE* buffer, uint32_t allocSize)
-    : _owner(owner), _buffer(buffer), _allocSize(allocSize)
+    : _owner(owner), _bufferPtr(buffer), _allocSize(allocSize)
 {
 }
 

--- a/ServerCoreLibrary/SendBuffer.h
+++ b/ServerCoreLibrary/SendBuffer.h
@@ -10,13 +10,13 @@ public:
     SendBuffer(std::shared_ptr<SendBufferChunk> owner, BYTE* buffer, uint32_t allocSize);
     ~SendBuffer() = default;
 
-    BYTE* Buffer() { return _buffer; }
+    BYTE* Buffer() { return _bufferPtr; }
     uint32_t        AllocSize() const { return _allocSize; }
     uint32_t        WriteSize() const { return _writeSize; }
     void            Close(uint32_t writeSize);
 
 private:
-    BYTE* _buffer;     // 실제 버퍼 포인터
+    BYTE* _bufferPtr;     // 실제 버퍼 포인터
     uint32_t        _allocSize = 0;   // 할당된 크기
     uint32_t        _writeSize = 0;   // 실제 쓰인 크기
     std::shared_ptr<SendBufferChunk> _owner;  // 소유자 청크


### PR DESCRIPTION
SendBuffer는 실제로 메모리를 소유하지 않고 SendBufferChunk의 일부 메모리를 가리키는 포인터를 가지고 있으므로


class SendBuffer::BYTE* _bufferPtr;